### PR TITLE
Biter Battles - Enhance Spectator Ghost mod for shoutcasters

### DIFF
--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -104,7 +104,7 @@ local function create_main_gui(player)
 		
 	local frame = player.gui.left.add { type = "frame", name = "bb_main_gui", direction = "vertical" }
 
-	if player.force.name ~= "spectator" then			
+	if player.force.name ~= "spectator" and player.force.name ~= "spectator_ghost" then			
 		frame.add { type = "table", name = "biter_battle_table", column_count = 4 }
 		local t = frame.biter_battle_table
 		local foods = {"automation-science-pack","logistic-science-pack","military-science-pack","chemical-science-pack","production-science-pack","utility-science-pack","space-science-pack","raw-fish"}
@@ -173,7 +173,7 @@ local function create_main_gui(player)
 	end
 	
 	local t = frame.add  { type = "table", column_count = 2 }
-	if player.force.name == "spectator" then
+	if player.force.name == "spectator" or player.force.name == "spectator_ghost" then
 		local b = t.add  { type = "sprite-button", name = "bb_leave_spectate", caption = "Join Team" }
 	else
 		local b = t.add  { type = "sprite-button", name = "bb_spectate", caption = "Spectate" }

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -46,11 +46,13 @@ local function init_forces()
 	game.create_force("south")
 	game.create_force("south_biters")	
 	game.create_force("spectator")
+	game.create_force("spectator_ghost")
 	
 	local f = game.forces["north"]
 	f.set_spawn_position({0, -32}, surface)
 	f.set_cease_fire('player', true)
 	f.set_friend("spectator", true)
+	f.set_friend("spectator_ghost", true)
 	f.set_friend("south_biters", true)
 	f.share_chart = true
 	
@@ -58,6 +60,7 @@ local function init_forces()
 	f.set_spawn_position({0, 32}, surface)
 	f.set_cease_fire('player', true)
 	f.set_friend("spectator", true)
+	f.set_friend("spectator_ghost", true)
 	f.set_friend("north_biters", true)
 	f.share_chart = true
 	
@@ -67,6 +70,7 @@ local function init_forces()
 	f.set_friend("player", true)
 	--f.set_friend("enemy", true)
 	f.set_friend("spectator", true)
+	f.set_friend("spectator_ghost", true)
 	f.share_chart = false
 		
 	local f = game.forces["south_biters"]
@@ -75,6 +79,7 @@ local function init_forces()
 	f.set_friend("player", true)
 	--f.set_friend("enemy", true)
 	f.set_friend("spectator", true)
+	f.set_friend("spectator_ghost", true)
 	f.share_chart = false
 	
 	--local f = game.forces["enemy"]
@@ -90,12 +95,28 @@ local function init_forces()
 	f.set_cease_fire("south_biters", true)
 	f.set_friend("north", true)
 	f.set_friend("south", true)
+	f.set_cease_fire("spectator_ghost", true)
 	f.set_cease_fire("player", true)
 	f.share_chart = true
+	
+	local f = game.forces["spectator_ghost"]
+	f.set_spawn_position({0,0},surface)
+	f.technologies["toolbelt"].researched=true	
+	f.set_cease_fire("north_biters", true)
+	f.set_cease_fire("south_biters", true)
+	f.set_friend("north", true)
+	f.set_friend("south", true)
+	f.set_cease_fire("spectator", true)
+	f.set_cease_fire("player", true)
+	f.share_chart = false
+	rendering.draw_light{sprite="utility/light_small", scale=999, surface=surface, target={0,0}, forces={f}}
+	local r = 200
+	f.chart(surface, {{r * -1, r * -1}, {r, r}})
 	
 	local f = game.forces["player"]
 	f.set_spawn_position({0,0},surface)
 	f.set_cease_fire('spectator', true)
+	f.set_cease_fire("spectator_ghost", true)
 	f.set_cease_fire("north_biters", true)
 	f.set_cease_fire("south_biters", true)
 	f.set_cease_fire('north', true)

--- a/maps/biter_battles_v2/on_tick.lua
+++ b/maps/biter_battles_v2/on_tick.lua
@@ -22,10 +22,14 @@ local function spy_fish()
 end
 
 local function reveal_map()
-	for _, f in pairs({"north", "south", "player", "spectator"}) do
+	for _, f in pairs({"north", "south", "player", "spectator", "spectator_ghost"}) do
 		local r = 768
 		game.forces[f].chart(game.surfaces["biter_battles"], {{r * -1, r * -1}, {r, r}})
 	end
+end
+
+local function spectator_ghost_reveal_map()
+	game.forces["spectator_ghost"].rechart()
 end
 
 local function clear_corpses()
@@ -60,6 +64,7 @@ local function on_tick(event)
 
 	if game.tick % 300 ~= 0 then return end
 	spy_fish()
+	spectator_ghost_reveal_map()
 	if global.bb_game_won_by_team then
 		reveal_map()
 		server_restart()


### PR DESCRIPTION
ghost spectator has all charted map chunks revealed continuously and a constant light across the map so always visible.
intended for shout casting and long term watching of games.
spectator ghost can only be accessed via the Team Manager as before to avoid players abusing it to scout. Players can be moved from ghost spectate straight to a team.
GUIs restricted for active players shouldn't be visible just like they aren't to the spectator team.