### PR TITLE
fixed spelling in rocks_yield_ore_veins.lua

### DIFF
--- a/modules/rocks_yield_ore_veins.lua
+++ b/modules/rocks_yield_ore_veins.lua
@@ -29,7 +29,7 @@ local size_raffle = {
 		{"giant", 65, 96},
 		{"huge", 33, 64},
 		{"big", 17, 32},
-		{"smol", 9, 16},
+		{"small", 9, 16},
 		{"tiny", 4, 8},
 	}
 


### PR DESCRIPTION
I noticed that small was spelled wrong in the message that plays when ore veins are discovered. I corrected the spelling in rocks_yield_ore_veins.lua. I am guessing the message auto-generates from the values in the size_raffle dictionary, but if there are other places I need to change the spelling just let me know.