### PR TITLE
mines do not allow town spread

### DIFF
--- a/modules/towny/building.lua
+++ b/modules/towny/building.lua
@@ -25,7 +25,6 @@ local entity_type_whitelist = {
 	["infinity-pipe"] = true,
 	["inserter"] = true,
 	["lamp"] = true,
-	["land-mine"] = true,
 	["loader"] = true,
 	["logistic-container"] = true,
 	["market"] = true,


### PR DESCRIPTION
given that some people have been spamming them all over the map, this should slow them down a bit