### PR TITLE
Send "join team" messages to discord

### DIFF
--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -1,4 +1,5 @@
 local Public = {}
+local Server = require 'utils.server'
 
 local bb_config = require "maps.biter_battles_v2.config"
 local event = require 'utils.event'
@@ -309,7 +310,9 @@ function join_team(player, force_name, forced_join)
 	if not forced_join then
 		local c = player.force.name
 		if global.tm_custom_name[player.force.name] then c = global.tm_custom_name[player.force.name] end
-		game.print(player.name .. " has joined team " .. c .. "!", {r = 0.98, g = 0.66, b = 0.22})
+		local message = player.name .. " has joined team " .. c .. "!"
+		game.print(message, {r = 0.98, g = 0.66, b = 0.22})
+		Server.to_discord(message)
 	end
 	local i = player.get_inventory(defines.inventory.character_main)
 	i.clear()

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -310,7 +310,7 @@ function join_team(player, force_name, forced_join)
 	if not forced_join then
 		local c = player.force.name
 		if global.tm_custom_name[player.force.name] then c = global.tm_custom_name[player.force.name] end
-		local message = player.name .. " has joined team " .. c .. "!"
+		local message = table.concat({player.name, " has joined team ", c, "!"})
 		game.print(message, {r = 0.98, g = 0.66, b = 0.22})
 		Server.to_discord(message)
 	end

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -312,7 +312,7 @@ function join_team(player, force_name, forced_join)
 		if global.tm_custom_name[player.force.name] then c = global.tm_custom_name[player.force.name] end
 		local message = table.concat({player.name, " has joined team ", c, "!"})
 		game.print(message, {r = 0.98, g = 0.66, b = 0.22})
-		Server.to_discord(message)
+		Server.to_discord_bold(message)
 	end
 	local i = player.get_inventory(defines.inventory.character_main)
 	i.clear()


### PR DESCRIPTION
It will be possible to know who plays in what team (even if they don't appear in the scoreboard) from discord logs.

I run the scenario locally to test, message was printed to chat as before. I don't know how to test discord integration.