### PR TITLE
Biter Battle: Improve terrain generation performance

### DIFF
--- a/maps/biter_battles_v2/mirror_terrain.lua
+++ b/maps/biter_battles_v2/mirror_terrain.lua
@@ -205,7 +205,7 @@ end
 
 local function ticking_work()
 	if not global.ctp then return end
-	local work = global.mws or 1024 -- define the number of work per tick here (for copies, creations, deletions)
+	local work = global.mws or 512 -- define the number of work per tick here (for copies, creations, deletions)
 	-- 136.5333 is the number of work needed to finish 4*(32*32) operations over 30 ticks (spreading a chunk copy over 30 ticks)
 	local w = 0
 	local i = global.ctp.continue

--- a/maps/biter_battles_v2/mirror_terrain.lua
+++ b/maps/biter_battles_v2/mirror_terrain.lua
@@ -107,6 +107,22 @@ local function process_entity(surface, entity)
 	entity_copy_functions[entity.type](surface, entity, mirror_position)
 end
 
+
+local function mirror_tiles(surface, source_area) 
+	mirrored = {}
+
+	local i = 0
+	for x = source_area.left_top.x, source_area.left_top.x+31 do
+		for y = source_area.left_top.y, source_area.left_top.y+31 do
+			local tile = surface.get_tile(x, y)
+			mirrored[i] = {name = tile.name, position = {-x, -y - 1}}
+			i = i + 1
+		end
+	end
+	
+    surface.set_tiles(mirrored, true)
+end
+
 local function clear_chunk(surface, area)
 	surface.destroy_decoratives{area=area}
 	if area.left_top.y > 32 or area.left_top.x > 32 or area.left_top.x < -32 then
@@ -163,6 +179,13 @@ local function on_chunk_generated(event)
 	global.chunks_to_mirror[game.tick + delay][#global.chunks_to_mirror[game.tick + delay] + 1] = {x = x / 32, y = y / 32}
 end
 
+local function add_work(work) 
+	if not global.ctp then global.ctp = { continue = 1, last = 0 } end
+	local idx = global.ctp.last + 1
+	global.ctp[idx] = work 
+	global.ctp.last = idx
+end
+
 local function ocg (event)
 	if event.area.left_top.y < 0 then return end
 	if event.surface.name ~= "biter_battles" then return end
@@ -176,17 +199,13 @@ local function ocg (event)
 
 	local x = ((event.area.left_top.x + 16) * -1) - 16
 	local y = ((event.area.left_top.y + 16) * -1) - 16
+	add_work({x = x / 32, y = y / 32, state = 1})
 
-	if not global.ctp then global.ctp = { continue = 1, last = 0 } end
-	local idx = global.ctp.last + 1
-	global.ctp[idx] = {x = x / 32, y = y / 32, state = 1}
-	global.ctp.last = idx
 end
-
 
 local function ticking_work()
 	if not global.ctp then return end
-	local work = global.mws or 512 -- define the number of work per tick here (for copies, creations, deletions)
+	local work = global.mws or 1024 -- define the number of work per tick here (for copies, creations, deletions)
 	-- 136.5333 is the number of work needed to finish 4*(32*32) operations over 30 ticks (spreading a chunk copy over 30 ticks)
 	local w = 0
 	local i = global.ctp.continue
@@ -204,8 +223,12 @@ local function ticking_work()
 	}
 	local surface = game.surfaces["biter_battles"]
 	if not surface.is_chunk_generated(c) then
-		-- game.print("Chunk not generated yet, requesting..")
-		surface.request_to_generate_chunks({x = area.left_top.x - 16, y = area.left_top.y - 16}, 1)
+		--game.print("Chunk not generated yet, requesting..")
+		surface.request_to_generate_chunks({x = area.left_top.x + 16, y = area.left_top.y + 16}, 0)
+		-- requeue
+		add_work(c)
+		global.ctp.continue = i+1
+		global.ctp[i] = nil 
 		return
 	end
 
@@ -215,16 +238,7 @@ local function ticking_work()
 			list = function () return surface.find_entities_filtered({area = inverted_area, name = "character", invert = true}) end,
 			action = function (e) e.destroy() end
 		},
-		[2] = {
-			name = "Tile copy",
-			list = function () return surface.find_tiles_filtered({area = area}) end,
-			action = function (tile)
-				surface.set_tiles({{
-					name = tile.name,
-					position = {x = tile.position.x * -1, y = (tile.position.y * -1) - 1}
-				}}, true)
-			end
-		},
+		[2] = {},
 		[3] = {
 			name = "Entity copy",
 			list = function () return surface.find_entities_filtered({area = area}) end,
@@ -246,24 +260,31 @@ local function ticking_work()
 		}
 	}
 
-	local task = tasks[c.state]
-	-- game.print(task.name)
-	d = d or task.list()
-	local last_idx = nil
-	for k, v in pairs(d) do
-		task.action(v)
-		d[k] = nil
-		last_idx = k
-		w = w + 1
-		if w > work then break end
-	end
 
-	local next_idx, _ = next(d, last_idx)
-	if next_idx == nil then
-		c.state = c.state + 1
-		c.data = nil
-	else
-		c.data = d
+    if c.state == 2 then 
+        mirror_tiles(surface, area)
+        c.state = c.state + 1
+        c.data = nil
+    else
+		local task = tasks[c.state]
+		-- game.print(task.name)
+		d = d or task.list()
+		local last_idx = nil
+		for k, v in pairs(d) do
+			task.action(v)
+			d[k] = nil
+			last_idx = k
+			w = w + 1
+			if w > work then break end
+		end
+		
+		local next_idx, _ = next(d, last_idx)
+		if next_idx == nil then
+			c.state = c.state + 1
+			c.data = nil
+		else
+			c.data = d
+		end
 	end
 
 	if c.state == 5 then

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -146,28 +146,31 @@ function is_horizontal_border_river(pos)
 end
 
 local function generate_inner_spawn_circle(pos, distance_to_center, surface)
+	-- assert(distance_to_center < spawn_circle_size) == true
 	local tile = false
-	if distance_to_center < spawn_circle_size then
+	if distance_to_center < 7 then 
+		tile = "sand-1"
+	elseif distance_to_center < 9.5 then 
+		tile = "refined-concrete"
+	else
 		tile = "deepwater"
 		if math_random(1, 48) == 1 then surface.create_entity({name = "fish", position = pos}) end
 	end
-	if distance_to_center < 9.5 then tile = "refined-concrete" end
-	if distance_to_center < 7 then tile = "sand-1" end
-	if tile then surface.set_tiles({{name = tile, position = pos}}, true) end
+
+	surface.set_tiles({{name = tile, position = pos}}, true)
 end
 
 local function generate_starting_area(pos, distance_to_center, surface)
+	-- assert(distance_to_center >= spawn_circle_size) == true
 	local r = 116
 	local noise = get_noise(2, pos) * 15
 
-	if distance_to_center + noise < r - 10 and distance_to_center > spawn_circle_size and not is_horizontal_border_river(pos) then
+	if distance_to_center + noise < r - 10 and not is_horizontal_border_river(pos) then
 		local tile_name = surface.get_tile(pos).name
 		if tile_name == "water" or tile_name == "deepwater" then
 			surface.set_tiles({{name = get_replacement_tile(surface, pos), position = pos}}, true)
 		end
 	end
-
-	if tile then surface.set_tiles({{name = tile, position = pos}}, true) end
 
 	if surface.can_place_entity({name = "wooden-chest", position = pos}) and surface.can_place_entity({name = "coal", position = pos}) then
 		local noise_2 = get_noise(3, pos)

--- a/utils/simplex_noise.lua
+++ b/utils/simplex_noise.lua
@@ -29,6 +29,11 @@ for i=0,511 do
 	perm[i+1] = p[bit32.band(i, 255) + 1]
 end
 
+-- special case of dot with 3 inputs
+local function dot2(g, x, y)
+	return x * g[1] + y *g[2]
+end
+
 local function dot(g, ...)
 	local v = {...}
 	local sum = 0
@@ -38,16 +43,17 @@ local function dot(g, ...)
 	return sum
 end
 
+local F2 = 0.5*(math.sqrt(3.0)-1.0)
+local G2 = (3.0-math.sqrt(3.0))/6.0
+
 function Simplex.d2(xin, yin,seed)
 	xin = xin + seed
 	yin = yin + seed
 	local n0, n1, n2	-- Noise contributions from the three corners
 	-- Skew the input space to determine which simplex cell we're in
-	local F2 = 0.5*(math.sqrt(3.0)-1.0)
 	local s = (xin+yin)*F2; -- Hairy factor for 2D
 	local i = math.floor(xin+s)
 	local j = math.floor(yin+s)
-	local G2 = (3.0-math.sqrt(3.0))/6.0
 	local t = (i+j)*G2
 	local X0 = i-t -- Unskew the cell origin back to (x,y) space
 	local Y0 = j-t
@@ -70,34 +76,39 @@ function Simplex.d2(xin, yin,seed)
 	local y1 = y0 - j1 + G2
 	local x2 = x0 - 1 + 2 * G2 -- Offsets for last corner in (x,y) unskewed coords
 	local y2 = y0 - 1 + 2 * G2
+
 	-- Work out the hashed gradient indices of the three simplex corners
 	local ii = bit32.band(i, 255)
 	local jj = bit32.band(j, 255)
 	local gi0 = perm[ii + perm[jj+1]+1] % 12
 	local gi1 = perm[ii + i1 + perm[jj + j1+1]+1] % 12
 	local gi2 = perm[ii + 1 + perm[jj + 1+1]+1] % 12
+
 	-- Calculate the contribution from the three corners
 	local t0 = 0.5 - x0 * x0 - y0 * y0
 	if t0 < 0 then
 		n0 = 0.0
 	else
 		t0 = t0 * t0
-		n0 = t0 * t0 * dot(grad3[gi0+1], x0, y0) -- (x,y) of grad3 used for 2D gradient
+		n0 = t0 * t0 * dot2(grad3[gi0+1], x0, y0) -- (x,y) of grad3 used for 2D gradient
 	end
+
 	local t1 = 0.5 - x1 * x1 - y1 * y1
 	if t1 < 0 then
 		n1 = 0.0
 	else
 		t1 = t1 * t1
-		n1 = t1 * t1 * dot(grad3[gi1+1], x1, y1)
+		n1 = t1 * t1 * dot2(grad3[gi1+1], x1, y1)
 	end
+
 	local t2 = 0.5 - x2 * x2 - y2 * y2
 	if t2 < 0 then
 		n2 = 0.0
 	else
 		t2 = t2 * t2
-		n2 = t2 * t2 * dot(grad3[gi2+1], x2, y2)
+		n2 = t2 * t2 * dot2(grad3[gi2+1], x2, y2)
 	end
+
 	-- Add contributions from each corner to get the final noise value.
 	-- The result is scaled to return values in the interval [-1,1].
 	return 70.0 * (n0 + n1 + n2)


### PR DESCRIPTION
These commits improve the performance of terrain generation and chunk mirroring by about 40% on my machine (compared to master).

Terrain generation:
* Less chunks have to go through the generate_circle_spawn body, since they are outside of the circle. 
* get_noise is only called if necessary as it's quite expensive.
* Improved get_noise and Simplex.d2 performance slightly.

Chunk mirroring:
* Tile mirroring is done by collecting all tiles first and then calling set_tiles once.
* Move a chunk to the end of the work queue, while the source chunk is waiting to be generated.

Bug Fixes:
*  If the source chunk was missing when mirroring a chunk the wrong / too many chunks were requested
