### PR TITLE
Improve main attack performance

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -375,7 +375,6 @@ end
 
 
 Public.perform_main_attack = function()
-	print("perform_main_attack")
 	if global.main_attack_wave_amount > 0 then
 		local surface = game.surfaces["biter_battles"]
 		local force_name = global.next_attack

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -139,6 +139,8 @@ local function get_random_close_spawner(surface, biter_force_name)
 	--
 	-- Option 1
 	--
+	
+	if false then
 	local rand_value = math_random(1, 10)
 
 	-- assume north_biters first
@@ -153,13 +155,14 @@ local function get_random_close_spawner(surface, biter_force_name)
 		area_name = "middle"
 		area = middle_spawner_area
 	end
+	end
 
 	--
 	-- Option 2
 	--
 
-	-- area = whole_spawner_area
-	-- area_name = whole
+	local area = whole_spawner_area
+	local area_name = "whole"
 
 	-- After here it's the same
 

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -35,9 +35,9 @@ local threat_values = {
 }
 
 -- these areas are for north
--- local left_spawner_area   = {left_top = {-2000, -1200}, right_bottom = {-800, -700}}
--- local right_spawner_area  = {left_top = {800,   -1200}, right_bottom = {2000, -700}}
--- local middle_spawner_area = {left_top = {-600,  -1000}, right_bottom = {600,  -400}}
+local left_spawner_area   = {left_top = {-2000, -1200}, right_bottom = {-800, -700}}
+local right_spawner_area  = {left_top = {800,   -1200}, right_bottom = {2000, -700}}
+local middle_spawner_area = {left_top = {-600,  -1000}, right_bottom = {600,  -400}}
 local whole_spawner_area  = {left_top = {-2048, -1400}, right_bottom = {2048, -400}}
 
 local function get_active_biter_count(biter_force_name)

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -35,9 +35,9 @@ local threat_values = {
 }
 
 -- these areas are for north
-local left_spawner_area   = {left_top = {-2000, -1200}, right_bottom = {-800, -700}}
-local right_spawner_area  = {left_top = {800,   -1200}, right_bottom = {2000, -700}}
-local middle_spawner_area = {left_top = {-600,  -1000}, right_bottom = {600,  -400}}
+-- local left_spawner_area   = {left_top = {-2000, -1200}, right_bottom = {-800, -700}}
+-- local right_spawner_area  = {left_top = {800,   -1200}, right_bottom = {2000, -700}}
+-- local middle_spawner_area = {left_top = {-600,  -1000}, right_bottom = {600,  -400}}
 local whole_spawner_area  = {left_top = {-2048, -1400}, right_bottom = {2048, -400}}
 
 local function get_active_biter_count(biter_force_name)
@@ -132,69 +132,21 @@ Public.send_near_biters_to_silo = function()
 end
 
 local function get_random_close_spawner(surface, biter_force_name)
-	-- Here we have two options:
-	-- 1. Random the area (left, middle, right) => smaller area to search
-	-- 2. Search the whole area => larger area => if it's not cached we get a lag spike (~20ms)
-
-	--
-	-- Option 1
-	--
-	
-	if false then
-	local rand_value = math_random(1, 10)
-
-	-- assume north_biters first
-	local area = nil
-	if rand_value == 1 then
-		area_name = "left"
-		area = left_spawner_area
-	elseif rand_value == 2 then
-		area_name = "right"
-		area = right_spawner_area
-	else
-		area_name = "middle"
-		area = middle_spawner_area
-	end
-	end
-
-	--
-	-- Option 2
-	--
-
 	local area = whole_spawner_area
-	local area_name = "whole"
-
-	-- After here it's the same
-
 	-- If south_biters: Mirror area along x-axis
 	if biter_force_name == "south_biters" then
-		area_name = area_name .. "_south"
 		area = {left_top = {area.left_top[1], -1*area.right_bottom[2]}, right_bottom = {area.right_bottom[1], -1*area.left_top[2]}}
 	end
 
-	-- If possible get the spawners from cache
-	-- TODO: If a spawner was destroyed, we still have it in cache, this is fine for now as we just use spawner.position
-	local spawners = nil
-	if not global.cached_spawners then global.cached_spawners = {} end
-	if global.cached_spawners[area_name] then
-		spawners = global.cached_spawners[area_name]
-	else
-		spawners = surface.find_entities_filtered({type = "unit-spawner", force = biter_force_name, area = area})	
-		global.cached_spawners[area_name] = spawners
-	end
-
+	local spawners = surface.find_entities_filtered({type = "unit-spawner", force = biter_force_name, area = area})
 	if not spawners[1] then return false end
 
 	local spawner = spawners[math_random(1,#spawners)]
-	-- game.forces["north"].add_chart_tag("biter_battles", {icon={type="virtual", name="signal-green"}, position=spawner.position})
 	for i = 1, 5, 1 do
 		local spawner_2 = spawners[math_random(1,#spawners)]
-		-- game.forces["north"].add_chart_tag("biter_battles", {icon={type="virtual", name="signal-green"}, position=spawner_2.position})
 		if spawner_2.position.x ^ 2 + spawner_2.position.y ^ 2 < spawner.position.x ^ 2 + spawner.position.y ^ 2 then spawner = spawner_2 end	
 	end	
 	
-	-- rendering.draw_rectangle{color={g=1}, width=5, filled=false, left_top=area.left_top, right_bottom=area.right_bottom, surface="biter_battles"}
-	-- game.forces["north"].add_chart_tag("biter_battles", {icon={type="virtual", name="signal-blue"}, position=spawner.position})	
 	return spawner
 end
 
@@ -447,13 +399,5 @@ function Public.subtract_threat(entity)
 	global.bb_threat[entity.force.name] = global.bb_threat[entity.force.name] - threat_values[entity.name]
 	return true
 end
-
--- Invalidate the cache if a new chunk was generated
--- TODO: This can be more precise
-Public.on_chunk_generated = function(event)
-	if event.area.right_bottom.x < -2048 then return end
-	if event.area.left_top.x > 2048 then return end
-	global.cached_spawners = {}
-end
-
+ 
 return Public

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -34,6 +34,12 @@ local threat_values = {
 	["spitter-spawner"] = 16
 }
 
+-- these areas are for north
+local left_spawner_area   = {left_top = {-2000, -1200}, right_bottom = {-800, -700}}
+local right_spawner_area  = {left_top = {800,   -1200}, right_bottom = {2000, -700}}
+local middle_spawner_area = {left_top = {-600,  -1000}, right_bottom = {600,  -400}}
+local whole_spawner_area  = {left_top = {-2048, -1400}, right_bottom = {2048, -400}}
+
 local function get_active_biter_count(biter_force_name)
 	local count = 0
 	for _, biter in pairs(global.active_biters[biter_force_name]) do
@@ -43,7 +49,15 @@ local function get_active_biter_count(biter_force_name)
 end
 
 local function set_biter_raffle_table(surface, biter_force_name)
-	local biters = surface.find_entities_filtered({type = "unit", force = biter_force_name})
+	-- It's fine to only sample the middle
+	local area = middle_spawner_area
+	
+	-- If south_biters: Mirror area along x-axis
+	if biter_force_name == "south_biters" then
+		area = {left_top = {area.left_top[1], -1*area.right_bottom[2]}, right_bottom = {area.right_bottom[1], -1*area.left_top[2]}}
+	end
+
+	local biters = surface.find_entities_filtered({type = "unit", force = biter_force_name, area = area})
 	if not biters[1] then return end
 	global.biter_raffle[biter_force_name] = {}
 	for _, e in pairs(biters) do
@@ -118,15 +132,66 @@ Public.send_near_biters_to_silo = function()
 end
 
 local function get_random_close_spawner(surface, biter_force_name)
-	local spawners = surface.find_entities_filtered({type = "unit-spawner", force = biter_force_name})	
+	-- Here we have two options:
+	-- 1. Random the area (left, middle, right) => smaller area to search
+	-- 2. Search the whole area => larger area => if it's not cached we get a lag spike (~20ms)
+
+	--
+	-- Option 1
+	--
+	local rand_value = math_random(1, 10)
+
+	-- assume north_biters first
+	local area = nil
+	if rand_value == 1 then
+		area_name = "left"
+		area = left_spawner_area
+	elseif rand_value == 2 then
+		area_name = "right"
+		area = right_spawner_area
+	else
+		area_name = "middle"
+		area = middle_spawner_area
+	end
+
+	--
+	-- Option 2
+	--
+
+	-- area = whole_spawner_area
+	-- area_name = whole
+
+	-- After here it's the same
+
+	-- If south_biters: Mirror area along x-axis
+	if biter_force_name == "south_biters" then
+		area_name = area_name .. "_south"
+		area = {left_top = {area.left_top[1], -1*area.right_bottom[2]}, right_bottom = {area.right_bottom[1], -1*area.left_top[2]}}
+	end
+
+	-- If possible get the spawners from cache
+	-- TODO: If a spawner was destroyed, we still have it in cache, this is fine for now as we just use spawner.position
+	local spawners = nil
+	if not global.cached_spawners then global.cached_spawners = {} end
+	if global.cached_spawners[area_name] then
+		spawners = global.cached_spawners[area_name]
+	else
+		spawners = surface.find_entities_filtered({type = "unit-spawner", force = biter_force_name, area = area})	
+		global.cached_spawners[area_name] = spawners
+	end
+
 	if not spawners[1] then return false end
-	
+
 	local spawner = spawners[math_random(1,#spawners)]
+	-- game.forces["north"].add_chart_tag("biter_battles", {icon={type="virtual", name="signal-green"}, position=spawner.position})
 	for i = 1, 5, 1 do
 		local spawner_2 = spawners[math_random(1,#spawners)]
+		-- game.forces["north"].add_chart_tag("biter_battles", {icon={type="virtual", name="signal-green"}, position=spawner_2.position})
 		if spawner_2.position.x ^ 2 + spawner_2.position.y ^ 2 < spawner.position.x ^ 2 + spawner.position.y ^ 2 then spawner = spawner_2 end	
 	end	
 	
+	-- rendering.draw_rectangle{color={g=1}, width=5, filled=false, left_top=area.left_top, right_bottom=area.right_bottom, surface="biter_battles"}
+	-- game.forces["north"].add_chart_tag("biter_battles", {icon={type="virtual", name="signal-blue"}, position=spawner.position})	
 	return spawner
 end
 
@@ -279,7 +344,7 @@ local function create_attack_group(surface, force_name, biter_force_name)
 		if global.bb_debug then game.print("No spawner found for team " .. force_name) end
 		return false 
 	end
-	
+
 	local nearest_player_unit = surface.find_nearest_enemy({position = spawner.position, max_distance = 2048, force = biter_force_name})
 	if not nearest_player_unit then nearest_player_unit = global.rocket_silo[force_name] end
 	
@@ -292,22 +357,37 @@ local function create_attack_group(surface, force_name, biter_force_name)
 	send_group(unit_group, force_name, nearest_player_unit)
 end
 
-Public.main_attack = function()
+Public.pre_main_attack = function()
 	local surface = game.surfaces["biter_battles"]
 	local force_name = global.next_attack
-	
+
 	if not global.training_mode or (global.training_mode and #game.forces[force_name].connected_players > 0) then
 		local biter_force_name = force_name .. "_biters"
-		local wave_amount = math.ceil(get_threat_ratio(biter_force_name) * 7)
-		
+		global.main_attack_wave_amount = math.ceil(get_threat_ratio(biter_force_name) * 7)
+
 		set_biter_raffle_table(surface, biter_force_name)
-		
-		for c = 1, wave_amount, 1 do		
-			create_attack_group(surface, force_name, biter_force_name)
-		end
-		if global.bb_debug then game.print(wave_amount .. " unit groups designated for " .. force_name .. " biters.") end
+
+		if global.bb_debug then game.print(global.main_attack_wave_amount .. " unit groups designated for " .. force_name .. " biters.") end
+	else
+		global.main_attack_wave_amount = 0
 	end
-	
+end
+
+
+Public.perform_main_attack = function()
+	print("perform_main_attack")
+	if global.main_attack_wave_amount > 0 then
+		local surface = game.surfaces["biter_battles"]
+		local force_name = global.next_attack
+		local biter_force_name = force_name .. "_biters"
+
+		create_attack_group(surface, force_name, biter_force_name)
+		global.main_attack_wave_amount = global.main_attack_wave_amount - 1	
+	end
+end
+
+Public.post_main_attack = function()
+	global.main_attack_wave_amount = 0
 	if global.next_attack == "north" then
 		global.next_attack = "south"
 	else
@@ -364,6 +444,14 @@ function Public.subtract_threat(entity)
 	end
 	global.bb_threat[entity.force.name] = global.bb_threat[entity.force.name] - threat_values[entity.name]
 	return true
+end
+
+-- Invalidate the cache if a new chunk was generated
+-- TODO: This can be more precise
+Public.on_chunk_generated = function(event)
+	if event.area.right_bottom.x < -2048 then return end
+	if event.area.left_top.x > 2048 then return end
+	global.cached_spawners = {}
 end
 
 return Public

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -107,6 +107,7 @@ local tick_minute_functions = {
 
 local function on_tick(event)
 	Mirror_terrain()	
+
 	local tick = game.tick
 
 	if tick % 60 == 0 then 
@@ -126,9 +127,10 @@ local function on_tick(event)
 		end
 	end
 
-	if tick % 30 ~= 0 then return end	
-	local key = tick % 3600
-	if tick_minute_functions[key] then tick_minute_functions[key]() end
+	if tick % 30 == 0 then	
+		local key = tick % 3600
+		if tick_minute_functions[key] then tick_minute_functions[key]() end
+	end
 end
 
 local function on_init()
@@ -148,7 +150,6 @@ Event.add(defines.events.on_player_joined_game, on_player_joined_game)
 Event.add(defines.events.on_research_finished, on_research_finished)
 Event.add(defines.events.on_robot_built_entity, on_robot_built_entity)
 Event.add(defines.events.on_tick, on_tick)
-Event.add(defines.events.on_chunk_generated, Ai.on_chunk_generated)
 Event.on_init(on_init)
 
 require "maps.biter_battles_v2.spec_spy"


### PR DESCRIPTION
This commit does 2 things:
1. Improve find_entities_filtered in set_biter_raffle_table and get_random_close_spawner by filtering by area => around 10x improvement!
2. Spread the load of the 7 waves and set_biter_raffle_table into individual ticks => spikes are 1/8 as high. 