### PR TITLE
planet_prison: fix double chunk generation bug

### DIFF
--- a/maps/planet_prison.lua
+++ b/maps/planet_prison.lua
@@ -469,6 +469,10 @@ local function make_ore_patch(e)
 end
 
 local function on_chunk_generated(e)
+   if e.surface.name ~= "arena" then
+      return
+   end
+
    make_ore_patch(e)
    _layers.push_bounding_box(e.area)
 end

--- a/maps/planet_prison/config.lua
+++ b/maps/planet_prison/config.lua
@@ -534,7 +534,7 @@ public.merchant_offer = {
 }
 
 public.manual = [[
-[font=heading-1]Planet Prison (1.0.0) - Manual[/font]
+[font=heading-1]Planet Prison (1.0.1) - Manual[/font]
 [font=default-bold]You did naughty things and was sent to this planet with a one way ticket. Once an industrial site, turned into non-hospitable planet due to pollution and war. Among other inmates, there are still bandits scavenging through the junk looking for rare items.
 
 This is an ultimate survival scenario with very hostile environment.


### PR DESCRIPTION
Unknowingly, the on_chunk_generated event was permitted to be processed
on 2 surfaces instead of the "arena" one, thus producing a "double
pass" effect. Since now, we'll filter based on name, which surface is
getting processed.