### PR TITLE
Improve main attack performance

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -185,6 +185,8 @@ local function get_random_close_spawner(surface, biter_force_name)
 	--
 	-- Option 1
 	--
+	
+	if false then
 	local rand_value = math_random(1, 10)
 
 	-- assume north_biters first
@@ -199,13 +201,14 @@ local function get_random_close_spawner(surface, biter_force_name)
 		area_name = "middle"
 		area = middle_spawner_area
 	end
+	end
 
 	--
 	-- Option 2
 	--
 
-	-- area = whole_spawner_area
-	-- area_name = whole
+	local area = whole_spawner_area
+	local area_name = "whole"
 
 	-- After here it's the same
 

--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -35,8 +35,6 @@ local threat_values = {
 }
 
 -- these areas are for north
-local left_spawner_area   = {left_top = {-2000, -1200}, right_bottom = {-800, -700}}
-local right_spawner_area  = {left_top = {800,   -1200}, right_bottom = {2000, -700}}
 local middle_spawner_area = {left_top = {-600,  -1000}, right_bottom = {600,  -400}}
 local whole_spawner_area  = {left_top = {-2048, -1400}, right_bottom = {2048, -400}}
 

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -110,8 +110,8 @@ local tick_minute_functions = {
 
 local function on_tick(event)
 	Mirror_terrain.ticking_work()
-	
-    local tick = game.tick
+
+	local tick = game.tick
 
 	if tick % 60 == 0 then 
 		global.bb_threat["north_biters"] = global.bb_threat["north_biters"] + global.bb_threat_income["north_biters"]
@@ -130,9 +130,10 @@ local function on_tick(event)
 		end
 	end
 
-	if tick % 30 ~= 0 then return end	
-	local key = tick % 3600
-	if tick_minute_functions[key] then tick_minute_functions[key]() end
+	if tick % 30 == 0 then	
+		local key = tick % 3600
+		if tick_minute_functions[key] then tick_minute_functions[key]() end
+	end
 end
 
 local function on_marked_for_deconstruction(event)
@@ -180,7 +181,6 @@ Event.add(defines.events.on_research_finished, on_research_finished)
 Event.add(defines.events.on_robot_built_entity, on_robot_built_entity)
 Event.add(defines.events.on_robot_built_tile, on_robot_built_tile)
 Event.add(defines.events.on_tick, on_tick)
-Event.add(defines.events.on_chunk_generated, Ai.on_chunk_generated)
 Event.on_init(on_init)
 
 Event.add_event_filter(defines.events.on_entity_damaged, { filter = "name", name = "rocket-silo" })

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -94,32 +94,43 @@ end
 local tick_minute_functions = {
 	[300 * 1] = Ai.raise_evo,
 	[300 * 2] = Ai.destroy_inactive_biters,
-	[300 * 3] = Ai.set_biter_raffle_table,	
-	[300 * 4] = Ai.main_attack,
-	[300 * 5] = Ai.send_near_biters_to_silo,
-	[300 * 6] = Ai.wake_up_sleepy_groups,
+	[300 * 3 + 30 * 0] = Ai.pre_main_attack,		-- setup for main_attack
+	[300 * 3 + 30 * 1] = Ai.perform_main_attack,	-- call perform_main_attack 7 times on different ticks
+	[300 * 3 + 30 * 2] = Ai.perform_main_attack,	-- some of these might do nothing (if there are no wave left)
+	[300 * 3 + 30 * 3] = Ai.perform_main_attack,
+	[300 * 3 + 30 * 4] = Ai.perform_main_attack,
+	[300 * 3 + 30 * 5] = Ai.perform_main_attack,
+	[300 * 3 + 30 * 6] = Ai.perform_main_attack,
+	[300 * 3 + 30 * 7] = Ai.perform_main_attack,
+	[300 * 3 + 30 * 8] = Ai.post_main_attack,
+	[300 * 4] = Ai.send_near_biters_to_silo,
+	[300 * 5] = Ai.wake_up_sleepy_groups,
 	[300 * 7] = Game_over.restart_idle_map,
 }
 
 local function on_tick(event)
 	Mirror_terrain.ticking_work()
+	
+    local tick = game.tick
 
-	local tick = game.tick
-
-	if tick % 60 ~= 0 then return end
-	global.bb_threat["north_biters"] = global.bb_threat["north_biters"] + global.bb_threat_income["north_biters"]
-	global.bb_threat["south_biters"] = global.bb_threat["south_biters"] + global.bb_threat_income["south_biters"]
+	if tick % 60 == 0 then 
+		global.bb_threat["north_biters"] = global.bb_threat["north_biters"] + global.bb_threat_income["north_biters"]
+		global.bb_threat["south_biters"] = global.bb_threat["south_biters"] + global.bb_threat_income["south_biters"]
+	end
 
 	if tick % 180 == 0 then Gui.refresh() end
 
-	if tick % 300 ~= 0 then return end
-	Gui.spy_fish()
-	if global.bb_game_won_by_team then
-		Game_over.reveal_map()
-		Game_over.server_restart()
-		return
+	if tick % 300 == 0 then
+		Gui.spy_fish()
+
+		if global.bb_game_won_by_team then
+			Game_over.reveal_map()
+			Game_over.server_restart()
+			return
+		end
 	end
 
+	if tick % 30 ~= 0 then return end	
 	local key = tick % 3600
 	if tick_minute_functions[key] then tick_minute_functions[key]() end
 end
@@ -169,6 +180,7 @@ Event.add(defines.events.on_research_finished, on_research_finished)
 Event.add(defines.events.on_robot_built_entity, on_robot_built_entity)
 Event.add(defines.events.on_robot_built_tile, on_robot_built_tile)
 Event.add(defines.events.on_tick, on_tick)
+Event.add(defines.events.on_chunk_generated, Ai.on_chunk_generated)
 Event.on_init(on_init)
 
 Event.add_event_filter(defines.events.on_entity_damaged, { filter = "name", name = "rocket-silo" })


### PR DESCRIPTION
This a rebased version (with two commits squashed) of #116.
I have tested it on map at 86% evo from Sunday and let it play out normally. Everything looks fine.
```
## 3600 ticks; 1 attack cycle
# pre
avg: 8.379 ms, min: 6.126 ms, max: 537.199 ms
avg: 8.533 ms, min: 6.064 ms, max: 538.407 ms
# post
avg: 8.178 ms, min: 6.050 ms, max: 106.591 ms
avg: 8.285 ms, min: 6.077 ms, max: 98.863 ms

## 7200 ticks; 2 attack cycles
# pre
avg: 8.192 ms, min: 5.940 ms, max: 543.868 ms
avg: 8.319 ms, min: 5.938 ms, max: 543.673 ms
# post
avg: 8.014 ms, min: 5.691 ms, max: 109.667 ms
avg: 8.125 ms, min: 5.953 ms, max: 107.933 ms
```