### PR TITLE
Improve discord logs of Biter Battles

### DIFF
--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -1,4 +1,5 @@
 local bb_config = require "maps.biter_battles_v2.config"
+local Server = require 'utils.server'
 
 local tables = require "maps.biter_battles_v2.tables"
 local food_values = tables.food_values
@@ -56,7 +57,9 @@ local function print_feeding_msg(player, food, flask_amount)
 	local formatted_amount = table.concat({"[font=heading-1][color=255,255,255]" .. flask_amount .. "[/color][/font]"})
 	
 	if flask_amount >= 20 then
-		game.print(colored_player_name .. " fed " .. formatted_amount .. " flasks of " .. formatted_food .. " to team " .. team_strings[get_enemy_team_of(player.force.name)] .. " biters!", {r = 0.9, g = 0.9, b = 0.9})
+		local msg = table.concat({colored_player_name, " fed ", formatted_amount, " flasks of ", formatted_food, " to team ", team_strings[get_enemy_team_of(player.force.name)], " biters!"})
+		game.print(msg, {r = 0.9, g = 0.9, b = 0.9})
+		Server.to_discord_bold(msg)
 	else
 		local target_team_text = "the enemy"
 		if global.training_mode then

--- a/maps/biter_battles_v2/gui.lua
+++ b/maps/biter_battles_v2/gui.lua
@@ -297,7 +297,9 @@ function join_team(player, force_name, forced_join)
 		player.character.destructible = true
 		Public.refresh()
 		game.permissions.get_group("Default").add_player(player)
-		game.print("Team " .. player.force.name .. " player " .. player.name .. " is no longer spectating.", {r = 0.98, g = 0.66, b = 0.22})
+		local msg = table.concat({"Team ", player.force.name, " player ", player.name, " is no longer spectating."})
+		game.print(msg, {r = 0.98, g = 0.66, b = 0.22})
+		Server.to_discord_bold(msg)
 		player.spectator = false
 		return
 	end
@@ -335,7 +337,9 @@ function spectate(player, forced_join)
 	player.force = game.forces.spectator
 	player.character.destructible = false
 	if not forced_join then
-		game.print(player.name .. " is spectating.", {r = 0.98, g = 0.66, b = 0.22})
+		local msg = player.name .. " is spectating."
+		game.print(msg, {r = 0.98, g = 0.66, b = 0.22})
+		Server.to_discord_bold(msg)
 	end
 	game.permissions.get_group("spectator").add_player(player)
 	global.spectator_rejoin_delay[player.name] = game.tick

--- a/maps/biter_battles_v2/team_manager.lua
+++ b/maps/biter_battles_v2/team_manager.lua
@@ -1,4 +1,5 @@
 local Public = {}
+local Server = require 'utils.server'
 
 local forces = {
 	{name = "north", color = {r = 0, g = 0, b = 200}},
@@ -81,6 +82,7 @@ local function switch_force(player_name, force_name)
 	player.force = game.forces[force_name]
 				
 	game.print(player_name .. " has been switched into team " .. force_name .. ".", {r=0.98, g=0.66, b=0.22})
+    Server.to_discord_bold(player_name .. " has joined team " .. force_name .. "!")
 	
 	leave_corpse(player)
 	


### PR DESCRIPTION
Following issues are addressed:
* there was no information about teams when in tournament mode,
* most spectators joined a team first to get a different GUI so they were treated as team members for the remainder of the game,
* there was no information about science send.

Test: send science, join team, start spectating, move players in tournament mode. Nothing is broken, but I still have no idea how to verify discord integration.

Hopefully, it doesn't make Comfylatron approach Discord's rate limit.
