### PR TITLE
[MUTAGENLOG]Fixed the loop not always doing 7 iterations for all science : crashing summary info of feeding

### DIFF
--- a/maps/biter_battles_v2/feeding.lua
+++ b/maps/biter_battles_v2/feeding.lua
@@ -113,7 +113,7 @@ local function add_stats(player, food, flask_amount,biter_force_name,evo_before_
 		if global.science_logs_total_north == nil then
 			global.science_logs_total_north = { 0 }
 			global.science_logs_total_south = { 0 }
-			for a = 1, flask_amount, 7 do	
+			for a = 1, 7 do	
 				table.insert(global.science_logs_total_north, 0)
 				table.insert(global.science_logs_total_south, 0)
 			end


### PR DESCRIPTION
https://github.com/M3wM3w/ComfyFactorio/issues/134
Bug fix of that.


How to reproduce bug before fix :
No one opens the mutagen log
Joins a team, feed 2 green science for example
Open the mutagen log, notice now that it is bugged (summary has at some place no "0")