### PR TITLE
Fix crash mutagen log

### DIFF
--- a/maps/biter_battles_v2/sciencelogs_tab.lua
+++ b/maps/biter_battles_v2/sciencelogs_tab.lua
@@ -196,6 +196,9 @@ end
 
 local build_config_gui = (function (player, frame)		
 	local frame_sciencelogs = comfy_panel_get_active_frame(player)
+	if not frame_sciencelogs then
+		return
+	end
 	frame_sciencelogs.clear()
 	add_science_logs(player, frame_sciencelogs)
 end)


### PR DESCRIPTION
Fix for this kind of crash : 
run headless, connect, open mutagen tab, open tournament-mode player management, move player to different team, crash