### PR TITLE
Biter Battle changes liked by community

### DIFF
--- a/maps/biter_battles_v2/ai.lua
+++ b/maps/biter_battles_v2/ai.lua
@@ -20,20 +20,20 @@ local size_of_vectors = #attack_vectors.north
 ]]
 
 local threat_values = {
-	["small-spitter"] = 1.5,
-	["small-biter"] = 1.5,
-	["medium-spitter"] = 4,
-	["medium-biter"] = 4,
-	["big-spitter"] = 12,
-	["big-biter"] = 12,
-	["behemoth-spitter"] = 32,
-	["behemoth-biter"] = 32,
-	["small-worm-turret"] = 8,
-	["medium-worm-turret"] = 12,
-	["big-worm-turret"] = 16,
-	["behemoth-worm-turret"] = 16,
-	["biter-spawner"] = 16,
-	["spitter-spawner"] = 16
+	["small-spitter"] = 3,
+	["small-biter"] = 3,
+	["medium-spitter"] = 5,
+	["medium-biter"] = 5,
+	["big-spitter"] = 10,
+	["big-biter"] = 10,
+	["behemoth-spitter"] = 28,
+	["behemoth-biter"] = 28,
+	["small-worm-turret"] = 1,
+	["medium-worm-turret"] = 1,
+	["big-worm-turret"] = 1,
+	["behemoth-worm-turret"] = 1,
+	["biter-spawner"] = 1,
+	["spitter-spawner"] = 1
 }
 
 -- these areas are for north

--- a/maps/biter_battles_v2/config.lua
+++ b/maps/biter_battles_v2/config.lua
@@ -17,7 +17,7 @@ local bb_config = {
 
 	--BITER SETTINGS--
 	["max_active_biters"] = 2000,					--Maximum total amount of attacking units per side.
-	["max_group_size"] = 256,						--Maximum unit group size.
+	["max_group_size"] = 512,						--Maximum unit group size.
 	["biter_timeout"] = 162000,						--Time it takes in ticks for an attacking unit to be deleted. This prevents perma stuck units.
 	["bitera_area_distance"] = 432					--Distance to the biter area.
 }

--- a/maps/biter_battles_v2/config.lua
+++ b/maps/biter_battles_v2/config.lua
@@ -11,7 +11,7 @@ local bb_config = {
 	["fast_pregen"] = false,	 						--Force fast pregeneration.
 
 	--TERRAIN OPTIONS--
-	["border_river_width"] = 36,						--Approximate width of the horizontal impassable river seperating the teams. (values up to 100)
+	["border_river_width"] = 48,						--Approximate width of the horizontal impassable river seperating the teams. (values up to 100)
 	["builders_area"] = true,							--Grant each side a peaceful direction with no nests and biters?
 	["random_scrap"] = true,							--Generate harvestable scrap around worms randomly?
 

--- a/maps/biter_battles_v2/main.lua
+++ b/maps/biter_battles_v2/main.lua
@@ -91,9 +91,21 @@ local function on_entity_damaged(event)
 	entity.health = entity.health + event.final_damage_amount
 end
 
+function prevent_negative_threat()
+	if global.bb_threat["north_biters"] < -100 then
+		global.bb_threat["north_biters"] = global.bb_threat["north_biters"] * -1
+		game.print("North's negative threat is now positive!")
+	end
+	if global.bb_threat["south_biters"] < -100 then
+		global.bb_threat["south_biters"] = global.bb_threat["south_biters"] * -1
+		game.print("South's negative threat is now positive!")
+	end
+end
+
 local tick_minute_functions = {
 	[300 * 1] = Ai.raise_evo,
 	[300 * 2] = Ai.destroy_inactive_biters,
+	[300 * 2 + 30 * 1] = prevent_negative_threat,
 	[300 * 3 + 30 * 0] = Ai.pre_main_attack,		-- setup for main_attack
 	[300 * 3 + 30 * 1] = Ai.perform_main_attack,	-- call perform_main_attack 7 times on different ticks
 	[300 * 3 + 30 * 2] = Ai.perform_main_attack,	-- some of these might do nothing (if there are no wave left)

--- a/maps/biter_battles_v2/terrain.lua
+++ b/maps/biter_battles_v2/terrain.lua
@@ -339,7 +339,7 @@ local function generate_river(event)
 end
 
 local function generate_potential_spawn_ore(surface)
-	local r = 130
+	local r = 150
 	local area = {{r * -1, r * -1}, {r, 0}}
 	local ores = {}
 	ores["iron-ore"] = surface.count_entities_filtered({name = "iron-ore", area = area})
@@ -347,7 +347,7 @@ local function generate_potential_spawn_ore(surface)
 	ores["coal"] = surface.count_entities_filtered({name = "coal", area = area})
 	ores["stone"] = surface.count_entities_filtered({name = "stone", area = area})
 	for ore, ore_count in pairs(ores) do
-		if ore_count < 1000 or ore_count == nil then
+		if ore_count < 2400 or ore_count == nil then
 			local pos = {}
 			for a = 1, 32, 1 do
 				pos = {x = -96 + math_random(0, 192), y = -20 - math_random(0, 96)}
@@ -355,7 +355,7 @@ local function generate_potential_spawn_ore(surface)
 					break
 				end
 			end
-			draw_noise_ore_patch(pos, ore, surface, math_random(18, 24), math_random(1500, 2000))
+			draw_noise_ore_patch(pos, ore, surface, 20, 3000)
 		end
 	end
 end


### PR DESCRIPTION
One test game was run and players liked 4 out of 5 presented changes.
In summary:
* wider river - no direct PvP,
* adjusted threat levels - easier early game, slightly harder mid and late game,
* increased ore in the starting area - outposting is no longer a must,
* prevent negative threat farming - remove broken mechanic from the game.