### PR TITLE
fix for soft reset deleting deconstructed entities

### DIFF
--- a/modules/no_deconstruction_of_neutral_entities.lua
+++ b/modules/no_deconstruction_of_neutral_entities.lua
@@ -5,6 +5,7 @@ local blacklist = {
 
 local function on_marked_for_deconstruction(event)
 	local entity = event.entity
+	if not entity.valid then return end
 	if not event.player_index then return end
 	if entity.force.name ~= "neutral" then return end
 	if blacklist[entity.type] then return end


### PR DESCRIPTION
soft reset deletes entities before they can get unmarked for deconstruction