### PR TITLE
Railway Troopers - Infinite Ore

### DIFF
--- a/maps/railway_troopers/main.lua
+++ b/maps/railway_troopers/main.lua
@@ -180,7 +180,7 @@ local function draw_east_side(surface, left_top)
 				surface.set_tiles({{name = "out-of-map", position = position}}, true)
 			else
 				if math_random(1, 5000) == 1 and left_top.x > 0 then
-					table_insert(entities, {name = infini_ores[math_random(1, #infini_ores)], position = position, amount = 99999999})
+					table_insert(entities, {name = infini_ores[math_random(1, #infini_ores)], position = position, amount = 99999999999})
 					table_insert(entities, {name = "burner-mining-drill", position = position, force = "neutral"})				
 				end
 			end		
@@ -195,7 +195,7 @@ local function draw_east_side(surface, left_top)
 			else
 				e.direction = 0
 			end
-			e.minable = false
+			e.minable = true
 			e.destructible = false
 			e.insert({name = "coal", count = math_random(8, 36)})
 		end
@@ -237,6 +237,8 @@ local type_whitelist = {
 	["transport-belt"] = true,
 	["underground-belt"] = true,
 	["wall"] = true,
+	["beacon"] = true,
+	["mining-drill"] = true,
 }
 
 local function deny_building(event)


### PR DESCRIPTION
I had the feeling that the infinite ores are lacking due to 
a) that they are using burner drills, requiring a constant supply of coal.
b) that they are too slow. The time it takes to mine the whole patch is nearly infinite, but since defences can't be placed, its often not worth the time to defend the area.

To combat this, I added electric mining drills and beacons to the whitelist. 
That way, players can mine a patch more quickly and its worth to defend. Since the patch is now mined faster, I also set the ore to 4.2G.