### PR TITLE
Use localized item names for autostash flying text

### DIFF
--- a/modules/autostash.lua
+++ b/modules/autostash.lua
@@ -41,7 +41,7 @@ local function create_floaty_text(surface, position, name, count)
                 position.x,
                 position.y + autostash.floating_text_y_offsets[position.x .. '_' .. position.y]
             },
-            text = '-' .. count .. ' ' .. name,
+            text = {'', '-', count, ' ', game.item_prototypes[name].localised_name},
             color = {r = 255, g = 255, b = 255}
         }
     )


### PR DESCRIPTION
Before:
![Before](https://user-images.githubusercontent.com/27060268/86134825-5d616900-baea-11ea-808d-cd8a94ca4c54.png)

After:
![After](https://user-images.githubusercontent.com/27060268/86134872-66ead100-baea-11ea-8619-4869b8674831.png)

