### PR TITLE
Make crafting grief prevention more aggressive! (and not abusive to server)

### DIFF
--- a/antigrief.lua
+++ b/antigrief.lua
@@ -619,7 +619,7 @@ local function on_player_cancelled_crafting(event)
     local crafting_queue_canceled_item_slot_count = #event.items
 
     if crafting_queue_canceled_item_slot_count > player_inventory_free_slot_count then
-        player.character.character_inventory_slots_bonus = crafting_queue_canceled_item_slot_count + player_inventory_free_slot_count
+        player.character.character_inventory_slots_bonus = crafting_queue_canceled_item_slot_count + #player.get_main_inventory()
         for i = 1, crafting_queue_canceled_item_slot_count do
             player.character.get_main_inventory().insert(event.items[i])
         end

--- a/antigrief.lua
+++ b/antigrief.lua
@@ -615,11 +615,11 @@ local function on_player_cancelled_crafting(event)
     local player = game.players[event.player_index]
 
     local crafting_queue_item_count = event.items.get_item_count()
-    local player_inventory_maximum_slot_count = #player.get_main_inventory()
+    local player_inventory_free_slot_count = player.get_main_inventory().count_empty_stacks()
     local crafting_queue_canceled_item_slot_count = #event.items
 
-    if crafting_queue_canceled_item_slot_count > player_inventory_maximum_slot_count then
-        player.character.character_inventory_slots_bonus = crafting_queue_canceled_item_slot_count + player_inventory_maximum_slot_count
+    if crafting_queue_canceled_item_slot_count > player_inventory_free_slot_count then
+        player.character.character_inventory_slots_bonus = crafting_queue_canceled_item_slot_count + player_inventory_free_slot_count
         for i = 1, crafting_queue_canceled_item_slot_count do
             player.character.get_main_inventory().insert(event.items[i])
         end


### PR DESCRIPTION
Kill player's character and hold all crafting queue in corpse (via pre-death inventory resize by bonus multiplier, same used in RPG system and returned by this system back to normal sizes), instead relying on Factorio's item placement, so no items are lost from team (and server as well :D )

Also corrected shown message on player abuse attempt:
as per https://lua-api.factorio.com/latest/LuaInventory.html#LuaInventory.operator%20# 
returned value wasn't an item count, but item stack count, so it's thing, that confused @hanakocz in late night conversation. Changed message to reflect actual item stack count/item count as well.

P.S. Not a Lua developer at all, so styleguide may be broken. And not native english speaker, so forgive me for mistranslations and feel free to ask weird readings.
P.P.S. Just noticed that styleguide was underscore_case, not camelCase, sorry, too much Golang :D Aditional commit to fix it on it's way.

Few images in work:

I've canceled massive craft queue:
![изображение](https://user-images.githubusercontent.com/3751049/88048899-ce7dc480-cb5c-11ea-8ef0-5410d5ac385a.png)

Inventory on same size, corpse have all items in it:
![изображение](https://user-images.githubusercontent.com/3751049/88048920-d63d6900-cb5c-11ea-85bc-da2cc94454b2.png)

Really all items :)
![изображение](https://user-images.githubusercontent.com/3751049/88048983-f3723780-cb5c-11ea-8383-6647d2aa7102.png)

