### PR TITLE
mount_fortress_v3 - potential bug and logic bug

### DIFF
--- a/maps/mountain_fortress_v3/ic/functions.lua
+++ b/maps/mountain_fortress_v3/ic/functions.lua
@@ -782,7 +782,7 @@ function Public.create_car(ic, event)
         return
     end
 
-    local name, mined = get_player_entity(ic, player, ce)
+    local name, mined = get_player_entity(ic, player)
 
     if entity_type[name] and not mined then
         return player.print('Multiple vehicles are not supported at the moment.', Color.warning)

--- a/maps/mountain_fortress_v3/ic/main.lua
+++ b/maps/mountain_fortress_v3/ic/main.lua
@@ -56,7 +56,7 @@ local function on_built_entity(event)
     if not ce or not ce.valid then
         return
     end
-    if not ce.type == 'car' or not ce.name == 'spidertron' then
+    if (ce.type == 'car' or ce.name == 'spidertron') ~= true then
         return
     end
 


### PR DESCRIPTION
ic/functions - unused third argument in get_player_entity call

ic/main - logic error - spidertron is not a car and function would fail to create a surface. precedence error - 'not' is higher than '=='. double-error instead was calling create_car every time a player built an entity.